### PR TITLE
 Add python3-dev for Reticulate package 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update -y \
   libssh2-1-dev \
   libsodium-dev \
   libv8-dev \
+  python3-dev \
   && apt-get clean
 
 # Install Base Packages


### PR DESCRIPTION
Adding python3-dev to the image allows the reticulate library to work. Tested successfully with on my dev VM.