### PR TITLE
Add libxt6

### DIFF
--- a/4.0.4/Dockerfile
+++ b/4.0.4/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update -y \
   libssh2-1-dev \
   libsodium-dev \
   libv8-dev \
+  libxt6 \
   python3-dev \
   && apt-get clean
 


### PR DESCRIPTION
Following solution in https://notes.rmhogervorst.nl/post/2020/09/23/solving-libxt-so-6-cannot-open-shared-object-in-grdevices-grsoftversion/